### PR TITLE
Add bloom filter in beacon structure

### DIFF
--- a/mari/association.c
+++ b/mari/association.c
@@ -401,7 +401,7 @@ void mr_assoc_handle_beacon(uint8_t *packet, uint8_t length, uint8_t channel, ui
 
     bool from_my_gateway = beacon->src == mr_mac_get_synced_gateway();
     if (from_my_gateway && mr_assoc_is_joined()) {
-        bool still_joined = mr_bloom_node_contains(mr_device_id(), packet + sizeof(mr_beacon_packet_header_t));
+        bool still_joined = mr_bloom_node_contains(mr_device_id(), beacon->bloom_filter);
         if (!still_joined) {
             // node no longer joined to this gateway, so need to leave
             assoc_vars.is_pending_disconnect = MARI_PEER_LOST_BLOOM;

--- a/mari/packet.c
+++ b/mari/packet.c
@@ -47,7 +47,7 @@ size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, ui
         .remaining_capacity = remaining_capacity,
         .active_schedule_id = active_schedule_id,
     };
-    //add bloom filter
+    // add bloom filter
     mr_bloom_gateway_copy(beacon.bloom_filter);
     memcpy(buffer, &beacon, sizeof(mr_beacon_packet_header_t));
     return sizeof(mr_beacon_packet_header_t);

--- a/mari/packet.c
+++ b/mari/packet.c
@@ -47,6 +47,8 @@ size_t mr_build_packet_beacon(uint8_t *buffer, uint16_t net_id, uint64_t asn, ui
         .remaining_capacity = remaining_capacity,
         .active_schedule_id = active_schedule_id,
     };
+    //add bloom filter
+    mr_bloom_gateway_copy(beacon.bloom_filter);
     memcpy(buffer, &beacon, sizeof(mr_beacon_packet_header_t));
     return sizeof(mr_beacon_packet_header_t);
 }

--- a/mari/packet.h
+++ b/mari/packet.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <nrf.h>
+#include "bloom.h"
 
 //=========================== defines ==========================================
 
@@ -56,6 +57,7 @@ typedef struct __attribute__((packed)) {
     uint64_t         src;
     uint8_t          remaining_capacity;
     uint8_t          active_schedule_id;
+    uint8_t          bloom_filter[MARI_BLOOM_M_BYTES];
 } mr_beacon_packet_header_t;
 
 typedef enum {

--- a/mari/queue.c
+++ b/mari/queue.c
@@ -60,9 +60,6 @@ uint8_t mr_queue_next_packet(slot_type_t slot_type, uint8_t *packet) {
                 mr_mac_get_asn(),
                 mr_scheduler_gateway_remaining_capacity(),
                 mr_scheduler_get_active_schedule_id());
-            if (mr_bloom_gateway_is_available()) {
-                len += mr_bloom_gateway_copy(packet + sizeof(mr_beacon_packet_header_t));
-            }
         } else if (slot_type == SLOT_TYPE_DOWNLINK) {
             if (mr_queue_has_join_packet()) {
                 len = mr_queue_get_join_packet(packet);

--- a/mari/scan.c
+++ b/mari/scan.c
@@ -137,21 +137,22 @@ bool mr_scan_select(mr_channel_info_t *best_channel_info, uint32_t ts_scan_start
 //=========================== private ==========================================
 
 inline void _save_rssi(size_t idx, mr_beacon_packet_header_t beacon, int8_t rssi, uint8_t channel, uint32_t ts_scan, uint64_t asn_scan) {
-    size_t channel_idx                                          = channel % MARI_N_BLE_REGULAR_CHANNELS;
+    size_t channel_idx = channel % MARI_N_BLE_REGULAR_CHANNELS;
+    // copy beacon without bloom filter to reduce memory consumption during scan
     mr_beacon_scan_header_t scan_beacon = {
-        .version = beacon.version,
-        .type = beacon.type,
-        .network_id = beacon.network_id,
-        .asn = beacon.asn,
-        .src = beacon.src,
+        .version            = beacon.version,
+        .type               = beacon.type,
+        .network_id         = beacon.network_id,
+        .asn                = beacon.asn,
+        .src                = beacon.src,
         .remaining_capacity = beacon.remaining_capacity,
         .active_schedule_id = beacon.active_schedule_id
     };
 
-    scan_vars.scans[idx].channel_info[channel_idx].rssi = rssi;
-    scan_vars.scans[idx].channel_info[channel_idx].timestamp = ts_scan;
+    scan_vars.scans[idx].channel_info[channel_idx].rssi         = rssi;
+    scan_vars.scans[idx].channel_info[channel_idx].timestamp    = ts_scan;
     scan_vars.scans[idx].channel_info[channel_idx].captured_asn = asn_scan;
-    scan_vars.scans[idx].channel_info[channel_idx].beacon = scan_beacon;
+    scan_vars.scans[idx].channel_info[channel_idx].beacon       = scan_beacon;
 }
 
 inline bool _scan_is_too_old(mr_gateway_scan_t scan, uint32_t ts_scan) {

--- a/mari/scan.c
+++ b/mari/scan.c
@@ -138,10 +138,20 @@ bool mr_scan_select(mr_channel_info_t *best_channel_info, uint32_t ts_scan_start
 
 inline void _save_rssi(size_t idx, mr_beacon_packet_header_t beacon, int8_t rssi, uint8_t channel, uint32_t ts_scan, uint64_t asn_scan) {
     size_t channel_idx                                          = channel % MARI_N_BLE_REGULAR_CHANNELS;
-    scan_vars.scans[idx].channel_info[channel_idx].rssi         = rssi;
-    scan_vars.scans[idx].channel_info[channel_idx].timestamp    = ts_scan;
+    mr_beacon_scan_header_t scan_beacon = {
+        .version = beacon.version,
+        .type = beacon.type,
+        .network_id = beacon.network_id,
+        .asn = beacon.asn,
+        .src = beacon.src,
+        .remaining_capacity = beacon.remaining_capacity,
+        .active_schedule_id = beacon.active_schedule_id
+    };
+
+    scan_vars.scans[idx].channel_info[channel_idx].rssi = rssi;
+    scan_vars.scans[idx].channel_info[channel_idx].timestamp = ts_scan;
     scan_vars.scans[idx].channel_info[channel_idx].captured_asn = asn_scan;
-    scan_vars.scans[idx].channel_info[channel_idx].beacon       = beacon;
+    scan_vars.scans[idx].channel_info[channel_idx].beacon = scan_beacon;
 }
 
 inline bool _scan_is_too_old(mr_gateway_scan_t scan, uint32_t ts_scan) {

--- a/mari/scan.h
+++ b/mari/scan.h
@@ -28,11 +28,22 @@
 
 //=========================== variables =======================================
 
+// a lightweight scan structure without bloom filter
+typedef struct __attribute__((packed)) {
+    uint8_t          version;
+    mr_packet_type_t type;
+    uint16_t         network_id;
+    uint64_t         asn;
+    uint64_t         src;
+    uint8_t          remaining_capacity;
+    uint8_t          active_schedule_id;
+} mr_beacon_scan_header_t;
+
 typedef struct {
     int8_t                    rssi;
     uint32_t                  timestamp;
     uint64_t                  captured_asn;
-    mr_beacon_packet_header_t beacon;
+    mr_beacon_scan_header_t beacon;
 } mr_channel_info_t;
 
 typedef struct {

--- a/mari/scan.h
+++ b/mari/scan.h
@@ -40,9 +40,9 @@ typedef struct __attribute__((packed)) {
 } mr_beacon_scan_header_t;
 
 typedef struct {
-    int8_t                    rssi;
-    uint32_t                  timestamp;
-    uint64_t                  captured_asn;
+    int8_t                  rssi;
+    uint32_t                timestamp;
+    uint64_t                captured_asn;
     mr_beacon_scan_header_t beacon;
 } mr_channel_info_t;
 


### PR DESCRIPTION
Fixes #122 

## Description

Added a proper field for bloom filter in the beacon structure, with necessary related updates in some functions.

---

## Testing of Node / Gateway (if applicable)

I tested this change with 1 node and 1 gateway.

---

## Additional Notes

A new lightweight structure **mr_beacon_scan_header_t** is created in **scan.h** since bloom filter is not needed during scan. This change is needed to prevent timing mismatches when the full beacon (after adding bloom filter) was used during scanning.
