### PR TITLE
Improvements on handover and stability

### DIFF
--- a/mari/mac.c
+++ b/mari/mac.c
@@ -160,9 +160,6 @@ void mr_mac_init(mr_event_cb_t event_callback) {
     mr_gpio_init(&pin3, MR_GPIO_OUT);
 #endif
 
-    // initialize the high frequency timer
-    mr_timer_hf_init(MARI_TIMER_DEV);
-
     // initialize the radio
     mr_radio_init(&isr_mac_radio_start_frame, &isr_mac_radio_end_frame, MR_RADIO_BLE_2MBit);
 

--- a/mari/mari.c
+++ b/mari/mari.c
@@ -15,6 +15,8 @@
 #include <string.h>
 
 #include "mr_device.h"
+#include "mr_rng.h"
+#include "mr_timer_hf.h"
 #include "models.h"
 #include "packet.h"
 #include "mac.h"
@@ -38,6 +40,7 @@ static mari_vars_t _mari_vars = { 0 };
 //=========================== prototypes =======================================
 
 static void event_callback(mr_event_t event, mr_event_data_t event_data);
+static void mr_mari_force_gateway_startup_random_delay(void);
 
 //=========================== public ===========================================
 // in this library, user-facing functions begin with mari_*, while internal functions begin with mr_*
@@ -48,12 +51,23 @@ void mari_init(mr_node_type_t node_type, uint16_t net_id, schedule_t *app_schedu
     _mari_vars.node_type          = node_type;
     _mari_vars.app_event_callback = app_event_callback;
 
+    // initialize drivers
+    mr_timer_hf_init(MARI_TIMER_DEV);
+    mr_rng_init();
+
+    // initialize stateful mari modules
     mr_assoc_init(net_id, event_callback);
     mr_scheduler_init(app_schedule);
-    mr_mac_init(event_callback);
     if (node_type == MARI_GATEWAY) {
         mr_bloom_gateway_init();
     }
+
+    if (node_type == MARI_GATEWAY) {
+        mr_mari_force_gateway_startup_random_delay();
+    }
+
+    // kick off the MAC state machine
+    mr_mac_init(event_callback);
 }
 
 void mari_tx(uint8_t *packet, uint8_t length) {
@@ -95,6 +109,17 @@ uint64_t mari_node_gateway_id(void) {
 }
 
 //=========================== iternal api =====================================
+
+void mr_mari_force_gateway_startup_random_delay(void) {
+    // in the gateway, defer the start of the MAC for a random time (between 0 and slotframe duration)
+    // this is to avoid gateway-to-gateway mutual cancellation, in case all gateways start at the same time
+    uint8_t rng_value;
+    mr_rng_read_u8(&rng_value);
+    // restrict random value to slotframe slot count
+    uint8_t  random_slot_count = rng_value % mr_scheduler_get_active_schedule_slot_count();
+    uint32_t delay_us          = random_slot_count * MARI_WHOLE_SLOT_DURATION;
+    mr_timer_hf_delay_us(MARI_TIMER_DEV, delay_us);
+}
 
 void mr_handle_packet(uint8_t *packet, uint8_t length) {
     mr_packet_header_t *header = (mr_packet_header_t *)packet;

--- a/mari/mari.c
+++ b/mari/mari.c
@@ -115,13 +115,10 @@ void mr_handle_packet(uint8_t *packet, uint8_t length) {
         switch (header->type) {
             case MARI_PACKET_JOIN_REQUEST:
             {
-                if (from_joined_node) {
-                    // already joined, ignore
-                    return;
-                }
                 // try to assign a cell to the node
                 // the asn-based keep-alive is also initialized
                 // the hashes h1 and h2 are also set
+                // NOTE: we accept re-joins because of possible collisions on the join response (downlink)
                 int16_t cell_id = mr_scheduler_gateway_assign_next_available_uplink_cell(header->src, mr_mac_get_asn());
                 if (cell_id >= 0) {
                     // at the packet level, max_nodes is limited to 256 (using uint8_t cell_id)


### PR DESCRIPTION
## Description

Improve:
- check packet tx before arming timers
- also do background scan on shared slots (of course bg scan only happens when already joined)
- fix to allow re-joins
- accumulate scan results during 1 slotframe before checking the handover condition
- reduce the chance that gateways will cross-cancel each other, by adding a random startup delay

---

## Testing of Node / Gateway (if applicable)

- I tested this change with `_100_` nodes and `_1_` gateways.
- I let it run for the following amount of time: `_20_` seconds

---

## Additional Notes

<!-- Add any additional info, screenshots, logs, or context here. -->
