### PR TITLE
Gateway: implement UART reception in bulk mode

### DIFF
--- a/app/03app_gateway_app/hdlc.c
+++ b/app/03app_gateway_app/hdlc.c
@@ -82,6 +82,14 @@ uint16_t _mr_hdlc_update_fcs(uint16_t fcs, uint8_t byte);
 
 //=========================== public ===========================================
 
+mr_hdlc_state_t mr_hdlc_reset(void) {
+    _hdlc_vars.buffer_pos  = 0;
+    _hdlc_vars.fcs         = MR_HDLC_FCS_INIT;
+    _hdlc_vars.state       = MR_HDLC_STATE_IDLE;
+    _hdlc_vars.escape_byte = false;
+    return _hdlc_vars.state;
+}
+
 mr_hdlc_state_t mr_hdlc_peek_state(void) {
     return _hdlc_vars.state;
 }

--- a/app/03app_gateway_app/hdlc.h
+++ b/app/03app_gateway_app/hdlc.h
@@ -35,6 +35,8 @@ typedef enum {
  */
 mr_hdlc_state_t mr_hdlc_rx_byte(uint8_t byte);
 
+mr_hdlc_state_t mr_hdlc_reset(void);
+
 /**
  * @brief   Peek at the current state of the HDLC decoder
  *

--- a/app/03app_gateway_app/main.c
+++ b/app/03app_gateway_app/main.c
@@ -24,16 +24,18 @@
 mr_gpio_t pin_hdlc_error        = { .port = 1, .pin = 5 };
 mr_gpio_t pin_hdlc_ready_decode = { .port = 1, .pin = 10 };
 // mr_gpio_t pin_dbg_ipc           = { .port = 1, .pin = 7 };
-mr_gpio_t pin_dbg_timer      = { .port = 1, .pin = 7 };
-mr_gpio_t pin_dbg_uart       = { .port = 1, .pin = 8 };
-mr_gpio_t pin_dbg_uart_write = { .port = 1, .pin = 9 };
+mr_gpio_t pin_dbg_timer = { .port = 1, .pin = 7 };
+mr_gpio_t pin_dbg_uart  = { .port = 1, .pin = 8 };
+// mr_gpio_t pin_dbg_uart_write = { .port = 1, .pin = 9 };
+mr_gpio_t pin_dbg_uart_new = { .port = 1, .pin = 9 };
 
 //=========================== defines ==========================================
 
 #define MR_UART_INDEX    (1)          ///< Index of UART peripheral to use
 #define MR_UART_BAUDRATE (1000000UL)  ///< UART baudrate used by the gateway
 
-#define TX_QUEUE_SIZE 4
+#define TX_QUEUE_SIZE            4
+#define UART_RX_RING_BUFFER_SIZE 512  ///< Size of the UART RX ring buffer
 
 typedef struct {
     uint8_t buffer[256];
@@ -41,12 +43,15 @@ typedef struct {
 } tx_frame_t;
 
 typedef struct {
-    // bool    uart_byte_received;
-    // uint8_t uart_byte;
+    uint8_t         buffer[UART_RX_RING_BUFFER_SIZE];  ///< Ring buffer for UART RX data
+    volatile size_t head;                              ///< Head pointer (write position)
+    volatile size_t tail;                              ///< Tail pointer (read position)
+    volatile size_t count;                             ///< Number of bytes in buffer
+} uart_ring_buffer_t;
 
-    bool    uart_buffer_received;
-    uint8_t uart_buffer[256];
-    size_t  uart_buffer_length;
+typedef struct {
+    uart_ring_buffer_t uart_rx_ring;         ///< UART RX ring buffer
+    bool               uart_data_available;  ///< Flag indicating new data is available
 
     uint8_t hdlc_encode_buffer[1024];  // Should be large enough
     bool    tx_pending;                // Flag for deferred TX (legacy)
@@ -155,6 +160,64 @@ static bool _tx_queue_dequeue(uint8_t *data, size_t *length) {
     return true;
 }
 
+//=========================== UART Ring Buffer functions ===================
+
+static bool _uart_ring_buffer_is_empty(void) {
+    return _app_vars.uart_rx_ring.count == 0;
+}
+
+static bool _uart_ring_buffer_is_full(void) {
+    return _app_vars.uart_rx_ring.count >= UART_RX_RING_BUFFER_SIZE;
+}
+
+static bool _uart_ring_buffer_put(uint8_t data) {
+    if (_uart_ring_buffer_is_full()) {
+        return false;  // Buffer full
+    }
+
+    _app_vars.uart_rx_ring.buffer[_app_vars.uart_rx_ring.head] = data;
+    _app_vars.uart_rx_ring.head                                = (_app_vars.uart_rx_ring.head + 1) % UART_RX_RING_BUFFER_SIZE;
+    _app_vars.uart_rx_ring.count++;
+
+    return true;
+}
+
+static bool __attribute__((unused)) _uart_ring_buffer_get(uint8_t *data) {
+    if (_uart_ring_buffer_is_empty()) {
+        return false;  // Buffer empty
+    }
+
+    *data                       = _app_vars.uart_rx_ring.buffer[_app_vars.uart_rx_ring.tail];
+    _app_vars.uart_rx_ring.tail = (_app_vars.uart_rx_ring.tail + 1) % UART_RX_RING_BUFFER_SIZE;
+    _app_vars.uart_rx_ring.count--;
+
+    return true;
+}
+
+static size_t _uart_ring_buffer_put_multiple(const uint8_t *buffer, size_t length) {
+    size_t bytes_written = 0;
+
+    for (size_t i = 0; i < length; i++) {
+        if (!_uart_ring_buffer_put(buffer[i])) {
+            break;  // Buffer full, stop writing
+        }
+        bytes_written++;
+    }
+
+    return bytes_written;
+}
+
+// static size_t _uart_ring_buffer_available(void) {
+//     return _app_vars.uart_rx_ring.count;
+// }
+
+static void _uart_ring_buffer_init(void) {
+    _app_vars.uart_rx_ring.head   = 0;
+    _app_vars.uart_rx_ring.tail   = 0;
+    _app_vars.uart_rx_ring.count  = 0;
+    _app_vars.uart_data_available = false;
+}
+
 // UART callback function
 // static void _uart_callback(uint8_t byte) {
 //     _app_vars.uart_byte          = byte;
@@ -166,9 +229,17 @@ static void _uart_callback(uint8_t *buffer, size_t length) {
         return;
     }
 
-    memcpy(_app_vars.uart_buffer, buffer, length);
-    _app_vars.uart_buffer_length   = length;
-    _app_vars.uart_buffer_received = true;
+    // Add received data to ring buffer
+    size_t bytes_written = _uart_ring_buffer_put_multiple(buffer, length);
+
+    // Set flag to indicate new data is available
+    if (bytes_written > 0) {
+        _app_vars.uart_data_available = true;
+    }
+
+    // TODO: Handle case where not all bytes were written (buffer full)
+    // For now, we just drop the excess data
+    (void)bytes_written;  // Suppress unused variable warning
 }
 
 int main(void) {
@@ -181,7 +252,8 @@ int main(void) {
     // mr_gpio_init(&pin_dbg_ipc, MR_GPIO_OUT);
     mr_gpio_init(&pin_dbg_timer, MR_GPIO_OUT);
     mr_gpio_init(&pin_dbg_uart, MR_GPIO_OUT);
-    mr_gpio_init(&pin_dbg_uart_write, MR_GPIO_OUT);
+    // mr_gpio_init(&pin_dbg_uart_write, MR_GPIO_OUT);
+    mr_gpio_init(&pin_dbg_uart_new, MR_GPIO_OUT);
 
     // Enable HFCLK with external 32MHz oscillator
     mr_hfclk_init();
@@ -189,6 +261,7 @@ int main(void) {
     _configure_ram_non_secure(2, 1);
     _init_ipc();
     mr_uart_init(MR_UART_INDEX, &_mr_uart_rx_pin, &_mr_uart_tx_pin, MR_UART_BAUDRATE, &_uart_callback);
+    _uart_ring_buffer_init();  // Initialize the UART ring buffer
 
     _release_network_core();
     // this is a bit hacky -- sometimes it does not work without this
@@ -197,18 +270,21 @@ int main(void) {
     while (1) {
         __WFE();
 
-        // if (_app_vars.uart_buffer_received) {
-        //     _app_vars.uart_buffer_received = false;
+        // if (_app_vars.uart_data_available) {
+        //     _app_vars.uart_data_available = false;
         //     // just toggle a debug pin
         //     mr_gpio_set(&pin_hdlc_ready_decode);
         //     mr_gpio_clear(&pin_hdlc_ready_decode);
         // }
 
-        if (_app_vars.uart_buffer_received) {
-            _app_vars.uart_buffer_received = false;
-            // use a loop to decode the whole buffer, testing the state machine at each byte
-            for (size_t i = 0; i < _app_vars.uart_buffer_length; i++) {
-                mr_hdlc_state_t hdlc_state = mr_hdlc_rx_byte(_app_vars.uart_buffer[i]);
+        if (_app_vars.uart_data_available) {
+            _app_vars.uart_data_available = false;
+            mr_gpio_set(&pin_dbg_uart_new);
+
+            // Process all available bytes in the ring buffer
+            uint8_t byte;
+            while (_uart_ring_buffer_get(&byte)) {
+                mr_hdlc_state_t hdlc_state = mr_hdlc_rx_byte(byte);
                 if (hdlc_state == MR_HDLC_STATE_READY) {
                     // decode the frame and send it to the radio
                     mr_gpio_set(&pin_hdlc_ready_decode);
@@ -239,8 +315,11 @@ int main(void) {
 
                     // // NOTE: since we didn't send a message to the radio (it was an error),
                     // // we can keep decoding the rest of the buffer, no need to break
+                } else {
+                    __NOP();
                 }
             }
+            mr_gpio_clear(&pin_dbg_uart_new);
         }
 
         // if (_app_vars.uart_byte_received) {
@@ -290,18 +369,18 @@ int main(void) {
 
             if (_tx_queue_dequeue(frame_data, &frame_len)) {
                 _app_vars.tx_frame_len = mr_hdlc_encode(frame_data, frame_len, _app_vars.hdlc_encode_buffer);
-                mr_gpio_set(&pin_dbg_uart_write);
+                // mr_gpio_set(&pin_dbg_uart_write);
                 mr_uart_write(MR_UART_INDEX, _app_vars.hdlc_encode_buffer, _app_vars.tx_frame_len);
-                mr_gpio_clear(&pin_dbg_uart_write);
+                // mr_gpio_clear(&pin_dbg_uart_write);
             }
         }
 
         // Handle deferred TX when UART becomes available (keep for compatibility)
         if (_app_vars.tx_pending && !mr_uart_tx_busy(MR_UART_INDEX)) {
             _app_vars.tx_pending = false;
-            mr_gpio_set(&pin_dbg_uart_write);
+            // mr_gpio_set(&pin_dbg_uart_write);
             mr_uart_write(MR_UART_INDEX, _app_vars.hdlc_encode_buffer, _app_vars.tx_frame_len);
-            mr_gpio_clear(&pin_dbg_uart_write);
+            // mr_gpio_clear(&pin_dbg_uart_write);
         }
     }
 }

--- a/app/03app_gateway_app/uart.c
+++ b/app/03app_gateway_app/uart.c
@@ -9,6 +9,7 @@
  * @copyright Inria, 2022
  */
 
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -21,11 +22,34 @@
 //=========================== defines ==========================================
 
 #if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
-#define NRF_POWER (NRF_POWER_S)
+#define NRF_POWER      (NRF_POWER_S)
+#define NRF_UART_TIMER (NRF_TIMER2_S)
+#define TIMER_CC_NUM   TIMER2_CC_NUM
+#define TIMER_IRQ      TIMER2_IRQn
 #elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
-#define NRF_POWER (NRF_POWER_NS)
+#define NRF_POWER      (NRF_POWER_NS)
+#define NRF_UART_TIMER (NRF_TIMER2_NS)
+#define TIMER_CC_NUM   TIMER2_CC_NUM
+#define TIMER_IRQ      TIMER2_IRQn
+#else
+#define NRF_UART_TIMER (NRF_TIMER4)
+#define TIMER_CC_NUM   TIMER4_CC_NUM
+#define TIMER_IRQ      TIMER4_IRQn
 #endif
+
+// #if defined(NRF5340_XXAA) && defined(NRF_APPLICATION)
+// #define NRF_POWER (NRF_POWER_S)
+// #elif defined(NRF5340_XXAA) && defined(NRF_NETWORK)
+// #define NRF_POWER (NRF_POWER_NS)
+// #endif
+
 #define MR_UARTE_CHUNK_SIZE (64U)
+
+typedef enum {
+    UART_RX_STATE_IDLE,
+    UART_RX_STATE_RX_TRIGGER_BYTE,
+    UART_RX_STATE_RX_CHUNK,
+} uart_rx_state_t;
 
 typedef struct {
     NRF_UARTE_Type *p;
@@ -34,12 +58,14 @@ typedef struct {
 
 typedef struct {
     // uint8_t      byte;       ///< the byte where received byte on UART is stored
-    uint8_t      rx_buffer[256];  ///< the buffer where received bytes on UART are stored
-    uart_rx_cb_t callback;        ///< pointer to the callback function
-    uint8_t     *tx_buffer;       ///< current TX buffer
-    size_t       tx_length;       ///< total bytes to transmit
-    size_t       tx_pos;          ///< current position in TX buffer
-    bool         tx_busy;         ///< flag indicating TX is in progress
+    uint8_t         rx_trigger_byte;  ///< the byte that triggers the RX state machine
+    uint8_t         rx_buffer[256];   ///< the buffer where received bytes on UART are stored
+    uart_rx_cb_t    callback;         ///< pointer to the callback function
+    uint8_t        *tx_buffer;        ///< current TX buffer
+    size_t          tx_length;        ///< total bytes to transmit
+    size_t          tx_pos;           ///< current position in TX buffer
+    bool            tx_busy;          ///< flag indicating TX is in progress
+    uart_rx_state_t rx_state;         ///< current state of the RX state machine
 } uart_vars_t;
 
 //=========================== variables ========================================
@@ -96,10 +122,16 @@ static const uart_conf_t _devs[UARTE_COUNT] = {
 };
 
 static uart_vars_t _uart_vars[UARTE_COUNT] = { 0 };  ///< variable handling the UART context
+static uart_t      _uart_global_index      = 0;
+
+//=========================== prototypes =======================================
+
+void mr_uart_start_rx(uart_t uart, uart_rx_state_t state);
 
 //=========================== public ===========================================
 
 void mr_uart_init(uart_t uart, const mr_gpio_t *rx_pin, const mr_gpio_t *tx_pin, uint32_t baudrate, uart_rx_cb_t callback) {
+    _uart_global_index = uart;
 
 #if defined(NRF5340_XXAA)
     if (baudrate > 460800) {
@@ -181,15 +213,27 @@ void mr_uart_init(uart_t uart, const mr_gpio_t *rx_pin, const mr_gpio_t *tx_pin,
     _devs[uart].p->ENABLE = (UARTE_ENABLE_ENABLE_Enabled << UARTE_ENABLE_ENABLE_Pos);
 
     if (callback) {
-        _uart_vars[uart].callback    = callback;
-        _devs[uart].p->RXD.MAXCNT    = 20;
-        _devs[uart].p->RXD.PTR       = (uint32_t)&_uart_vars[uart].rx_buffer;
-        _devs[uart].p->INTENSET      = (UARTE_INTENSET_ENDRX_Enabled << UARTE_INTENSET_ENDRX_Pos);
-        _devs[uart].p->SHORTS        = (UARTE_SHORTS_ENDRX_STARTRX_Enabled << UARTE_SHORTS_ENDRX_STARTRX_Pos);
-        _devs[uart].p->TASKS_STARTRX = 1;
+        // configure the UART for RX
+        _uart_vars[uart].callback = callback;
+
+        // setup the RX interrupt
+        _devs[uart].p->INTENSET = (UARTE_INTENSET_ENDRX_Enabled << UARTE_INTENSET_ENDRX_Pos);
+        // _devs[uart].p->SHORTS        = (UARTE_SHORTS_ENDRX_STARTRX_Enabled << UARTE_SHORTS_ENDRX_STARTRX_Pos);
+
+        // setup the RX state machine and start receiving
+        mr_uart_start_rx(uart, UART_RX_STATE_RX_TRIGGER_BYTE);
+
         NVIC_EnableIRQ(_devs[uart].irq);
         NVIC_SetPriority(_devs[uart].irq, MR_UART_IRQ_PRIORITY);
         NVIC_ClearPendingIRQ(_devs[uart].irq);
+
+        // configure the timer for RX
+        NRF_UART_TIMER->TASKS_CLEAR = 1;
+        NRF_UART_TIMER->PRESCALER   = 4;  // Run TIMER at 1MHz
+        NRF_UART_TIMER->BITMODE     = (TIMER_BITMODE_BITMODE_32Bit << TIMER_BITMODE_BITMODE_Pos);
+        NRF_UART_TIMER->INTENSET    = (1 << (TIMER_INTENSET_COMPARE0_Pos + TIMER_CC_NUM - 1));
+        NVIC_SetPriority(TIMER_IRQ, 2);
+        NVIC_EnableIRQ(TIMER_IRQ);
     }
 }
 
@@ -220,21 +264,58 @@ bool mr_uart_tx_busy(uart_t uart) {
     return _uart_vars[uart].tx_busy;
 }
 
+void mr_uart_start_rx(uart_t uart, uart_rx_state_t state) {
+    _uart_vars[uart].rx_state = state;
+    if (state == UART_RX_STATE_RX_TRIGGER_BYTE) {
+        _devs[uart].p->RXD.MAXCNT = 1;  // receive the trigger byte
+        _devs[uart].p->RXD.PTR    = (uint32_t)&_uart_vars[uart].rx_trigger_byte;
+    } else if (state == UART_RX_STATE_RX_CHUNK) {
+        _devs[uart].p->RXD.MAXCNT = 7;  // receive the rest of the chunk
+                                        // start receiving from the second byte to leave room for the trigger byte
+        _devs[uart].p->RXD.PTR = (uint32_t)&_uart_vars[uart].rx_buffer[1];
+    }
+    _devs[uart].p->TASKS_STARTRX = 1;  // start receiving
+}
+
 //=========================== interrupts =======================================
 
 #include "mr_gpio.h"
-extern mr_gpio_t pin_dbg_uart;
+extern mr_gpio_t pin_dbg_uart, pin_dbg_timer;
 static void      _uart_isr(uart_t uart) {
-    mr_gpio_set(&pin_dbg_uart);
 
     // check if the interrupt was caused by a fully received package
     if (_devs[uart].p->EVENTS_ENDRX) {
+        mr_gpio_set(&pin_dbg_uart);
         _devs[uart].p->EVENTS_ENDRX = 0;
         // make sure we actually received new data
         if (_devs[uart].p->RXD.AMOUNT != 0) {
-            // process the received buffer
-            _uart_vars[uart].callback(_uart_vars[uart].rx_buffer, _devs[uart].p->RXD.AMOUNT);
+            if (_uart_vars[uart].rx_state == UART_RX_STATE_RX_TRIGGER_BYTE && _devs[uart].p->RXD.AMOUNT == 1) {
+                // we received the trigger byte, so we can start receiving the chunk
+                mr_uart_start_rx(uart, UART_RX_STATE_RX_CHUNK);
+                // arm timer in case the chunk is not filled in time
+                NRF_UART_TIMER->TASKS_CLEAR          = 1;
+                NRF_UART_TIMER->CC[TIMER_CC_NUM - 1] = 1000;
+                NRF_UART_TIMER->TASKS_START          = 1;
+            } else if (_uart_vars[uart].rx_state == UART_RX_STATE_RX_CHUNK) {
+                // stop the timer
+                NRF_UART_TIMER->TASKS_STOP = 1;
+
+                // process the received buffer
+                size_t rx_length              = _devs[uart].p->RXD.AMOUNT + 1;     // +1 for the trigger byte
+                _uart_vars[uart].rx_buffer[0] = _uart_vars[uart].rx_trigger_byte;  // put the trigger byte at the beginning of the buffer
+                _uart_vars[uart].callback(_uart_vars[uart].rx_buffer, rx_length);
+
+                // all done, go back to receiving the trigger byte
+                mr_uart_start_rx(uart, UART_RX_STATE_RX_TRIGGER_BYTE);
+            } else {
+                // something went wrong, so we go back to receiving the trigger byte
+                mr_uart_start_rx(uart, UART_RX_STATE_RX_TRIGGER_BYTE);
+            }
+        } else {
+            // nothing received, so we go back to receiving the trigger byte
+            mr_uart_start_rx(uart, UART_RX_STATE_RX_TRIGGER_BYTE);
         }
+        mr_gpio_clear(&pin_dbg_uart);
     }
 
     // check if the interrupt was caused by TX completion
@@ -260,8 +341,6 @@ static void      _uart_isr(uart_t uart) {
             _devs[uart].p->INTENCLR = (UARTE_INTENCLR_ENDTX_Clear << UARTE_INTENCLR_ENDTX_Pos);
         }
     }
-
-    mr_gpio_clear(&pin_dbg_uart);
 };
 
 #if defined(NRF5340_XXAA)
@@ -292,3 +371,24 @@ void UARTE1_IRQHandler(void) {
     _uart_isr(1);
 }
 #endif
+
+#if defined(NRF5340_XXAA)
+void TIMER2_IRQHandler(void) {
+#else
+void TIMER4_IRQHandler(void) {
+#endif
+    if (NRF_UART_TIMER->EVENTS_COMPARE[TIMER_CC_NUM - 1]) {
+        NRF_UART_TIMER->EVENTS_COMPARE[TIMER_CC_NUM - 1] = 0;
+        NRF_UART_TIMER->TASKS_STOP                       = 1;
+
+        // tell the uart to stop receiving
+        // this will cause an ENDRX interrupt
+        _devs[_uart_global_index].p->TASKS_STOPRX = 1;
+
+        mr_gpio_set(&pin_dbg_timer);
+        mr_gpio_clear(&pin_dbg_timer);
+
+        // // back to receiving the trigger byte
+        // mr_uart_start_rx(_uart_global_index, UART_RX_STATE_RX_TRIGGER_BYTE);
+    }
+}

--- a/app/03app_gateway_app/uart.h
+++ b/app/03app_gateway_app/uart.h
@@ -23,7 +23,8 @@
 
 typedef uint8_t uart_t;  ///< UART peripheral index
 
-typedef void (*uart_rx_cb_t)(uint8_t data);  ///< Callback function prototype, it is called on each byte received
+// typedef void (*uart_rx_cb_t)(uint8_t data);  ///< Callback function prototype, it is called on each byte received
+typedef void (*uart_rx_cb_t)(uint8_t *buffer, size_t length);  ///< Callback function prototype, it is called on each byte received
 
 //=========================== public ===========================================
 
@@ -34,7 +35,7 @@ typedef void (*uart_rx_cb_t)(uint8_t data);  ///< Callback function prototype, i
  * @param[in] rx_pin    pointer to RX pin
  * @param[in] tx_pin    pointer to TX pin
  * @param[in] baudrate  Baudrate in bauds
- * @param[in] callback  callback function called on each received byte
+ * @param[in] callback  callback function called on each received buffer
  */
 void mr_uart_init(uart_t uart, const mr_gpio_t *rx_pin, const mr_gpio_t *tx_pin, uint32_t baudrate, uart_rx_cb_t callback);
 

--- a/app/03app_gateway_net/main.c
+++ b/app/03app_gateway_net/main.c
@@ -49,7 +49,7 @@ typedef struct {
 gateway_vars_t _app_vars = { 0 };
 
 extern schedule_t schedule_tiny, schedule_medium, schedule_big, schedule_huge;
-schedule_t       *schedule_app = &schedule_huge;
+schedule_t       *schedule_app = &schedule_tiny;
 
 volatile __attribute__((section(".shared_data"))) ipc_shared_data_t ipc_shared_data;
 

--- a/mari/mac.c
+++ b/mari/mac.c
@@ -225,10 +225,10 @@ static void set_slot_state(mr_mac_state_t state) {
         case STATE_RX_DATA_LISTEN:
         case STATE_TX_DATA:
         case STATE_RX_DATA:
-            DEBUG_GPIO_SET(&pin1);
+            // DEBUG_GPIO_SET(&pin1);
             break;
         case STATE_SLEEP:
-            DEBUG_GPIO_CLEAR(&pin1);
+            // DEBUG_GPIO_CLEAR(&pin1);
             DEBUG_GPIO_CLEAR(&pin2);  // pin2 might be SET in case a packet had just started to arrive, so set it low again
             break;
         default:


### PR DESCRIPTION
## Description

1. receive a trigger byte, setup dma for 31 bytes and arm a timeout
2. if received 31 bytes, pass the 32 bytes to application, if not, eventually the timeout expires, and then you pass anything you have to the application

---

## Testing of Node / Gateway (if applicable)

- I tested this change with `_10_` nodes and `_1_` gateways.
- I let it run for the following amount of time: `_5_` min

---

## Additional Notes

<!-- Add any additional info, screenshots, logs, or context here. -->
